### PR TITLE
Feat faster bam pipeline

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,11 @@ echo "threads=8" >> $toolspec
 echo >> $toolspec
 echo "// For exome pipeline only ***Edit before running the exome pipeline***" >> $toolspec
 echo "EXOME_TARGET=\"path/to/exome_target_regions.bed\"" >> $toolspec
+echo "// Uncomment the line below to run the STRetch installation test, or specify your own" >> $toolspec
+echo "//EXOME_TARGET=\"SCA8_region.bed\"" >> $toolspec
+echo >> $toolspec
+echo "// For bam pipeline only ***Edit before running if using CRAM input format***" >> $toolspec
+echo "CRAM_REF=\"path/to/reference_genome_used_to_create_cram.fasta\"" >> $toolspec
 echo >> $toolspec
 
 #set STRetch base directory
@@ -87,6 +92,10 @@ for c in $commands ; do
     fi
     echo "$c=\"$c_path\"" >> $toolspec
 done
+
+# Set location of groovy dependancies for gngs read extraction tool
+echo "GNGS_JAR=\"$installdir/tools/groovy-ngs-utils/1.0.7/groovy-ngs-utils.jar\""
+echo >> $toolspec
 
 if [ ! -f $refdir/*dedup.sorted.bed ] ; then
     mkdir -p $refdir

--- a/pipelines/pipeline_stages.groovy
+++ b/pipelines/pipeline_stages.groovy
@@ -3,7 +3,7 @@
 // Variables e.g. tools are set in pipeline_config.groovy
 
 // Amount to inflate STR regions by for remapping
-SLOP=800
+SLOP=5
 
 ///////////////////
 // Helper functions
@@ -93,10 +93,10 @@ align_bwa_bam = {
         exec """
             set -o pipefail
 
-            export JAVA_OPTS="-Dsamjdk.reference_fasta=$REF"
+            export JAVA_OPTS="-Dsamjdk.reference_fasta=$CRAM_REF"
 
             java -Xmx16g -cp $STRETCH/tools/bpipe-0.9.9.2/lib/bpipe.jar:$GNGS_JAR gngs.tools.Pairs 
-                -pad $SLOP -n 6
+                -pad $SLOP -n 1
                 $regionFlag $shardFlag -bam ${input[input_type]} |
                 $bwa mem -p -M -t ${threads-1}
                     -R "@RG\\tID:${sample}\\tPL:$PLATFORM\\tPU:NA\\tLB:${lane}\\tSM:${sample}"
@@ -236,7 +236,7 @@ str_targets = {
         exec """
             set -o pipefail
 
-            $bedtools slop -b $SLOP -i $input.bed -g ${REF}.genome | $bedtools merge > $output.bed
+            $bedtools merge -i $input.bed > $output.bed
         """
     //}
 }

--- a/scripts/identify_locus.py
+++ b/scripts/identify_locus.py
@@ -26,8 +26,8 @@ def parse_args():
     """Parse the input arguments, use '-h' for help"""
     parser = argparse.ArgumentParser(description='Reports counts of reads mapping to the STR decoy originating each STR locus.')
     parser.add_argument(
-        '--bam', type=str, required=True,
-        help='Bam file of mapped reads e.g. produced by Bowtie2 or BWA')
+        '--bam', type=str, required=True, nargs='+',
+        help='One or more BAM files of mapped reads e.g. produced by Bowtie2 or BWA. If multiple BAMs all are assumed to come from the same sample.')
     parser.add_argument(
         '--bed', type=str, required=False,
         help='bed file containing genomic locations of STR loci. Genomic locations should be relative to the fasta reference used to create the bam')
@@ -43,10 +43,10 @@ def randomletters(length):
    return ''.join(random.choice(string.ascii_lowercase) for i in range(length))
 
 def detect_readlen(bamfile, sample = 100):
-    """Samples reads from a bam file to detect the read length. Assumes uniform 
+    """Samples reads from a bam file to detect the read length. Assumes uniform
     read lengths and that any shorter reads are due to trimming or clipping.
     Args:
-        bamfile (str): Location of bamfile (will be opened and closed, so don't 
+        bamfile (str): Location of bamfile (will be opened and closed, so don't
             use an existing open bamfile handle).
         sample (int): Number of reads to sample.
 
@@ -74,84 +74,89 @@ def detect_readlen(bamfile, sample = 100):
 def main():
     # Parse command line arguments
     args = parse_args()
-    bamfile = args.bam
+    bamfiles = args.bam
     bedfile = args.bed
     outfile = args.output
 
-    if outfile:
-        outstream = open(outfile, 'w')
-    else:
-        outstream = sys.stdout
-
     max_distance = args.dist
+
+    # Check bamfiles have unique names
+    if len(set(bamfiles)) < len(bamfiles):
+        sys.exit('ERROR: There were multiple bamfiles with the same filename. Please check your input')
 
     #STR_bed = parse_bed(args.bed, position_base=0)
     STR_bed = bt.BedTool(bedfile)
     readlen, count_noCIGAR = detect_readlen(bamfile)
 
-    # Read bam
-    bam = pysam.Samfile(bamfile, 'rb')
+    all_results = []
+    for bamfile in bamfiles:
 
-    # Get relevant chromosomes
-    required_chroms = []
-    unpaired = 0
-    total = 0
-    for chrom in bam.references:
-        if chrom.startswith('STR-'):
-            required_chroms.append(chrom)
-    # Check if any STR- chromosomes
-    if len(required_chroms) == 0:
-       sys.exit('ERROR: There were no reads mapping to chromosomes with names starting with "STR-". Are you sure this data is mapped to a reference genome with STR decoy chromosomes?') 
+        # Read bam
+        bam = pysam.Samfile(bamfile, 'rb')
 
-    out_header = '\t'.join(['STR_chr', 'STR_start', 'STR_stop', 'motif', 'reflen', 'count'])
-    outstream.write(out_header + '\n')
+        # Get relevant chromosomes
+        required_chroms = []
+        unpaired = 0
+        total = 0
+        for chrom in bam.references:
+            if chrom.startswith('STR-'):
+                required_chroms.append(chrom)
+        # Check if any STR- chromosomes
+        if len(required_chroms) == 0:
+           sys.exit('ERROR: There were no reads mapping to chromosomes with names starting with "STR-" in {0}. Are you sure this data is mapped to a reference genome with STR decoy chromosomes?'.format(bamfile))
 
-    for chrom in required_chroms:
-        motif = chrom.split('-')[1]
-        all_positions = []
-        all_segments = bam.fetch(reference=chrom)
+        for chrom in required_chroms:
+            motif = chrom.split('-')[1]
+            all_positions = []
+            all_segments = bam.fetch(reference=chrom)
 
-        for read in all_segments:
-            total += 1
-            try:
-                mate_chr = read.next_reference_name
-            except ValueError:
-                unpaired += 1
-                continue
-            mate_start = read.next_reference_start
-            mate_stop = mate_start + readlen
-            all_positions.append([mate_chr, mate_start, mate_stop])
+            for read in all_segments:
+                total += 1
+                try:
+                    mate_chr = read.next_reference_name
+                except ValueError:
+                    unpaired += 1
+                    continue
+                mate_start = read.next_reference_start
+                mate_stop = mate_start + readlen
+                all_positions.append([mate_chr, mate_start, mate_stop])
 
-        # Strategy:
-        # Merge all overlapping intervals
-        # Keep the count of reads corresponding to each merged interval (i.e. 1 for each read contained in it)
-        # Assign each interval to the closest STR (within 500 bp? - the insert size) with the correct motif, adding together the count of reads
-        # Check motif: == normalise_str()
-        # There should be two 1-2 intervals per STR, likely one for each flank.
-        # Report the read count for each STR
+            # Strategy:
+            # Merge all overlapping intervals
+            # Keep the count of reads corresponding to each merged interval (i.e. 1 for each read contained in it)
+            # Assign each interval to the closest STR (within 500 bp? - the insert size) with the correct motif, adding together the count of reads
+            # Check motif: == normalise_str()
+            # There should be two 1-2 intervals per STR, likely one for each flank.
+            # Report the read count for each STR
 
-        if len(all_positions) > 0:
-            motif_bed = bt.BedTool(all_positions).sort()
-            # Merge all the intervals, then count how many of the original intervals overlap the merged ones (4th column)
-            motif_coverage = motif_bed.merge(stream=True).coverage(b=motif_bed, counts=True)
+            if len(all_positions) > 0:
+                motif_bed = bt.BedTool(all_positions).sort()
+                # Merge all the intervals, then count how many of the original intervals overlap the merged ones (4th column)
+                motif_coverage = motif_bed.merge(stream=True).coverage(b=motif_bed, counts=True)
 
-            tmp_bed = 'tmp-' + randomletters(8) + '.bed' #create temporary file for bedtools to write to and pandas to read since streams don't seem to work
-            closest_STR = motif_coverage.closest(STR_bed, d=True, stream=True).saveas(tmp_bed)
-            colnames = ['chr', 'start', 'stop', 'count', 'STR_chr', 'STR_start',
-            'STR_stop', 'motif', 'reflen', 'distance']
-            df = pd.read_csv(tmp_bed, sep='\t', header=None, names=colnames)
-            os.remove(tmp_bed) #delete temporary file
+                tmp_bed = 'tmp-' + randomletters(8) + '.bed' #create temporary file for bedtools to write to and pandas to read since streams don't seem to work
+                closest_STR = motif_coverage.closest(STR_bed, d=True, stream=True).saveas(tmp_bed)
+                colnames = ['chr', 'start', 'stop', 'count', 'STR_chr', 'STR_start',
+                'STR_stop', 'motif', 'reflen', 'distance']
+                df = pd.read_csv(tmp_bed, sep='\t', header=None, names=colnames)
+                os.remove(tmp_bed) #delete temporary file
 
-            # Filter out loci that are too far away
-            df = df.loc[df['distance'] <= max_distance, :]
-            df['motif'] = df['motif'].map(normalise_str) # Normalise the STR motif to enable comparisons
-            # Remove STRs that don't match the motif
-            df = df.loc[df['motif'] == normalise_str(motif), :]
-            df = df.loc[:, ['STR_chr', 'STR_start', 'STR_stop', 'motif', 'count', 'reflen']]
-            summed = df.groupby(['STR_chr', 'STR_start', 'STR_stop', 'motif', 'reflen'], as_index=False).aggregate(np.sum)
-            summed.to_csv(outstream, sep='\t', header=False, index=False)
+                # Filter out loci that are too far away
+                df = df.loc[df['distance'] <= max_distance, :]
+                df['motif'] = df['motif'].map(normalise_str) # Normalise the STR motif to enable comparisons
+                # Remove STRs that don't match the motif
+                df = df.loc[df['motif'] == normalise_str(motif), :]
+                df = df.loc[:, ['STR_chr', 'STR_start', 'STR_stop', 'motif', 'count', 'reflen']]
 
-    outstream.close()
+                all_results.append(df)
+
+    # Sum counts from multiple bam files and multiple rows
+    if len(all_results) == 1:
+        df_total = all_results[0]
+    else:
+        df_total = pd.concat(all_results, ignore_index=True)
+
+    summed = df_total.groupby(['STR_chr', 'STR_start', 'STR_stop', 'motif', 'reflen'], as_index=False).aggregate(np.sum)
 
     # Print a warning message in case of reads without a CIGAR string
     if count_noCIGAR > 0:
@@ -163,6 +168,17 @@ def main():
         sys.exit('ERROR: all {0} reads overlapping the target STR regions appear to be unpaired. You may wish to check your bam file is paired-end and correctly formed.\n'.format(total))
     elif unpaired > 0:
         sys.stderr.write('WARNING: it appears that {0} of the {1} reads overlapping the target STR regions were unpaired and so no useful data could be obtained from them.\n'.format(unpaired, total))
+
+    # Write results
+    if outfile:
+        outstream = open(outfile, 'w')
+    else:
+        outstream = sys.stdout
+
+    out_header = '\t'.join(['STR_chr', 'STR_start', 'STR_stop', 'motif', 'reflen', 'count'])
+    outstream.write(out_header + '\n')
+    summed_total.to_csv(outstream, sep='\t', header=False, index=False)
+    outstream.close()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Allow identify_locus.py to take multiple bams from the same sample
- Update install to set ngs tools, include CRAM_REF option
For bam pipeline:
- align_bwa_bam to default 1 concurrency
- use CRAM_REF instead of REF to for CRAM files
- set SLOP = 5, and only apply SLOP once (it was applied at both the bed generation stage and the read extraction stage)